### PR TITLE
Disable auto-capitalization of user-id textField in the login view

### DIFF
--- a/Ptt/Flows/LoginFlow/Controllers/LoginViewController.swift
+++ b/Ptt/Flows/LoginFlow/Controllers/LoginViewController.swift
@@ -234,6 +234,7 @@ final class LoginViewController: ASDKViewController<ASDisplayNode>, LoginView{
         
         textField.delegate = self
         textField.textColor = UIColor.black
+        textField.autocapitalizationType = .none
         
         textField.text = ""
         return textField


### PR DESCRIPTION
A minor UX related fix.   
I think most user-ids don't start from capital character, the auto-capitalization is such annoying.           
If you don't think this is a problem, feel free to close it :) 