### PR TITLE
Improve api test flexbility

### DIFF
--- a/Ptt.xcodeproj/project.pbxproj
+++ b/Ptt.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		3E9FE306275D01C5002E144F /* PopularArticlesSceneFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9FE305275D01C5002E144F /* PopularArticlesSceneFactoryProtocol.swift */; };
 		3E9FE309275D0240002E144F /* PopularArticlesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9FE308275D0240002E144F /* PopularArticlesViewController.swift */; };
 		3E9FE30B275D0F16002E144F /* PopularArticlesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9FE30A275D0F16002E144F /* PopularArticlesViewModel.swift */; };
+		3EA6F1B429B37CB4005D8B09 /* BoardListFakeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA6F1B329B37CB4005D8B09 /* BoardListFakeData.swift */; };
 		3ECAD05D2762766A00F50A91 /* NumberExtensionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECAD05C2762766A00F50A91 /* NumberExtensionTest.swift */; };
 		3ECAD060276277FF00F50A91 /* PopularArticles.json in Resources */ = {isa = PBXBuildFile; fileRef = 3ECAD05F276277FF00F50A91 /* PopularArticles.json */; };
 		3ED16B3E25713D64004A33E0 /* APITestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED16B3D25713D64004A33E0 /* APITestClient.swift */; };
@@ -159,6 +160,7 @@
 		3E9FE305275D01C5002E144F /* PopularArticlesSceneFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularArticlesSceneFactoryProtocol.swift; sourceTree = "<group>"; };
 		3E9FE308275D0240002E144F /* PopularArticlesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularArticlesViewController.swift; sourceTree = "<group>"; };
 		3E9FE30A275D0F16002E144F /* PopularArticlesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularArticlesViewModel.swift; sourceTree = "<group>"; };
+		3EA6F1B329B37CB4005D8B09 /* BoardListFakeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardListFakeData.swift; sourceTree = "<group>"; };
 		3ECAD05C2762766A00F50A91 /* NumberExtensionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberExtensionTest.swift; sourceTree = "<group>"; };
 		3ECAD05F276277FF00F50A91 /* PopularArticles.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = PopularArticles.json; sourceTree = "<group>"; };
 		3ED16B3D25713D64004A33E0 /* APITestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITestClient.swift; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 				3E8D8C86258A519F00346690 /* Login.json */,
 				3E9A6283258A5D9A00C9DC18 /* BoardList.json */,
 				3ECAD05F276277FF00F50A91 /* PopularArticles.json */,
+				3EA6F1B329B37CB4005D8B09 /* BoardListFakeData.swift */,
 			);
 			path = FakeData;
 			sourceTree = "<group>";
@@ -1087,6 +1090,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3EA6F1B429B37CB4005D8B09 /* BoardListFakeData.swift in Sources */,
 				3E0101A925669DEE00D39FAD /* MockURLSessionDataTask.swift in Sources */,
 				3E0101A325669DDB00D39FAD /* MockURLSession.swift in Sources */,
 				EA475F8C23C4834C000867FE /* PttTests.swift in Sources */,

--- a/Ptt.xcodeproj/xcshareddata/xcschemes/Ptt.xcscheme
+++ b/Ptt.xcodeproj/xcshareddata/xcschemes/Ptt.xcscheme
@@ -27,7 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      language = "en">
+      language = "en"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/PttTests/FakeData/BoardListFakeData.swift
+++ b/PttTests/FakeData/BoardListFakeData.swift
@@ -1,0 +1,123 @@
+//
+//  BoardList.swift
+//  PttTests
+//
+//  Created by AnsonChen on 2023/3/4.
+//  Copyright © 2023 Ptt. All rights reserved.
+//
+
+enum BoardListFakeData {
+    static var successData: [String: Any] = [
+        "list": [
+            [
+                "bid": "6_ALLPOST",
+                "brdname": "ALLPOST",
+                "title": "跨板式LOCAL新文章",
+                "flag": 32,
+                "type": "◎",
+                "class": "嘰哩",
+                "nuser": 0,
+                "moderators": [
+
+                ],
+                "reason": "",
+                "read": false,
+                "total": 0,
+                "last_post_time": 0,
+                "stat_attr": 0,
+                "level_idx": ""
+            ],
+            [
+                "bid": "11_EditExp",
+                "brdname": "EditExp",
+                "title": "範本精靈投稿區",
+                "flag": 0,
+                "type": "◎",
+                "class": "嘰哩",
+                "nuser": 0,
+                "moderators": [
+
+                ],
+                "reason": "",
+                "read": false,
+                "total": 0,
+                "last_post_time": 0,
+                "stat_attr": 0,
+                "level_idx": ""
+            ],
+            [
+                "bid": "8_Note",
+                "brdname": "Note",
+                "title": "動態看板及歌曲投稿",
+                "flag": 0,
+                "type": "◎",
+                "class": "嘰哩",
+                "nuser": 0,
+                "moderators": [
+
+                ],
+                "reason": "",
+                "read": false,
+                "total": 0,
+                "last_post_time": 0,
+                "stat_attr": 0,
+                "level_idx": ""
+            ],
+            [
+                "bid": "9_Record",
+                "brdname": "Record",
+                "title": "我們的成果",
+                "flag": 32,
+                "type": "◎",
+                "class": "嘰哩",
+                "nuser": 0,
+                "moderators": [
+
+                ],
+                "reason": "",
+                "read": false,
+                "total": 1,
+                "last_post_time": 0,
+                "stat_attr": 0,
+                "level_idx": ""
+            ],
+            [
+                "bid": "1_SYSOP",
+                "brdname": "SYSOP",
+                "title": "站長好!",
+                "flag": 32,
+                "type": "◎",
+                "class": "嘰哩",
+                "nuser": 0,
+                "moderators": [
+
+                ],
+                "reason": "",
+                "read": false,
+                "total": 0,
+                "last_post_time": 0,
+                "stat_attr": 0,
+                "level_idx": ""
+            ],
+            [
+                "bid": "10_WhoAmI",
+                "brdname": "WhoAmI",
+                "title": "呵呵，猜猜我是誰！",
+                "flag": 0,
+                "type": "◎",
+                "class": "嘰哩",
+                "nuser": 0,
+                "moderators": [
+
+                ],
+                "reason": "",
+                "read": true,
+                "total": 3,
+                "last_post_time": 0,
+                "stat_attr": 0,
+                "level_idx": ""
+            ]
+        ],
+        "next_idx": ""
+    ]
+}


### PR DESCRIPTION
* Introduce `MockURLSessionV2`.  

With `MockURLSessionV2` you are able to test request url or query items.    
Let's take `testBoardListSuccess_with_english_keyword` as an example.   
The request url will change based on different keyword, this can't be tested in the previous way.  
Not to mention query items, headers ...etc 

If you guys like this PR.  
`MockURLSession` will be removed, all of APIClient tests will be updated