### PR TITLE
Fix BoardListTVC tableview index out of range issue

### DIFF
--- a/Ptt/Flows/BoardListFlow/BoardListTVC.swift
+++ b/Ptt/Flows/BoardListFlow/BoardListTVC.swift
@@ -52,11 +52,8 @@ final class BoardListTVC: UITableViewController, BoardListView {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard
-            let cell = tableView.dequeueReusableCell(
-                withIdentifier: BoardsTableViewCell.cellID,
-                for: indexPath
-            ) as? BoardsTableViewCell
+        guard let cell =
+            tableView.dequeueReusableCell(withIdentifier: BoardsTableViewCell.cellID, for: indexPath) as? BoardsTableViewCell, indexPath.row < viewModel.list.count
         else {
             return UITableViewCell()
         }


### PR DESCRIPTION
<img width="1403" alt="截圖 2023-06-27 下午10 40 52" src="https://github.com/Ptt-official-app/Ptt-iOS/assets/21999535/946ebc2a-8462-4013-b233-e5487f958955">

Drag tableView, show index out of range.
It doesn't reproduce easy, but happen occasionally.

Add if check to sure indexPath.row small than list count.