### PR TITLE
Fix fetching favorite boards twice issue when launching app

### DIFF
--- a/Ptt/Flows/BoardListFlow/BoardListViewModel.swift
+++ b/Ptt/Flows/BoardListFlow/BoardListViewModel.swift
@@ -36,17 +36,19 @@ final class BoardListViewModel {
     }
 
     func fetchListData() {
-        if case .popular = listType {
+        switch listType {
+        case .popular:
             Task { await fetchPopularBoards() }
-        }
-        Task {
-            await fetchAllFavoriteBoards()
-            if case .favorite = listType {
-                list = favoriteBoards
-                startIndex = favoriteStartIndex
-                uiDelegate?.listDidUpdate()
+        case .favorite:
+            Task {
+                await fetchAllFavoriteBoards()
+                if case .favorite = listType {
+                    list = favoriteBoards
+                    startIndex = favoriteStartIndex
+                    uiDelegate?.listDidUpdate()
+                }
+                uiDelegate?.favoriteBoardsDidUpdate()
             }
-            uiDelegate?.favoriteBoardsDidUpdate()
         }
     }
 


### PR DESCRIPTION
Because the `BoardListViewModel` is shared type class which is shared on different boards.
```swfit
enum ListType {
        case favorite, popular
}
```
So the issue is causing by the original `fetchListData()` function implementations.
The intentional behavior is that two `BoardListViewModel` type lists will fetch their own type boards respectively.
But the fetching function logic is not separated properly, so the `ListTypeFavorite` view model will fetch **favorite** boards one time, and the `ListTypePopular` view model will fetch **favorite** & **popular** boards once each.

So the final requests will be the following:
- Favorite: 2 times
- Popular: 1 time

---
I modify that from `if` to `switch` statements to avoid unexpected execution flow.

![Screen_Shot_2023-07-26_at_1_26_04_AM](https://github.com/Ptt-official-app/Ptt-iOS/assets/3894279/cf5cd898-3120-418f-9ec3-f3af309f40e6)
