### PR TITLE
Fix duplicated favorite api call

### DIFF
--- a/Ptt.xcodeproj/project.pbxproj
+++ b/Ptt.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		3EC2CB4E29C888B800E70A45 /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2CB4D29C888B800E70A45 /* NotificationName.swift */; };
 		3EC2CB5029C88AF900E70A45 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2CB4F29C88AF900E70A45 /* String+Extension.swift */; };
 		3ECAD05D2762766A00F50A91 /* NumberExtensionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECAD05C2762766A00F50A91 /* NumberExtensionTest.swift */; };
+		3ED0485C2A7461F9004E78BD /* FavoriteBoardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED0485B2A7461F9004E78BD /* FavoriteBoardManager.swift */; };
 		3ED16B3E25713D64004A33E0 /* APITestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED16B3D25713D64004A33E0 /* APITestClient.swift */; };
 		3EDDC6DF29B453E000173F9F /* PostTypeSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EDDC6DE29B453E000173F9F /* PostTypeSelectionView.swift */; };
 		3EDDC6E129B4841B00173F9F /* ANSIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EDDC6E029B4841B00173F9F /* ANSIColor.swift */; };
@@ -197,6 +198,7 @@
 		3EC2CB4D29C888B800E70A45 /* NotificationName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		3EC2CB4F29C88AF900E70A45 /* String+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		3ECAD05C2762766A00F50A91 /* NumberExtensionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberExtensionTest.swift; sourceTree = "<group>"; };
+		3ED0485B2A7461F9004E78BD /* FavoriteBoardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteBoardManager.swift; sourceTree = "<group>"; };
 		3ED16B3D25713D64004A33E0 /* APITestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITestClient.swift; sourceTree = "<group>"; };
 		3EDDC6DE29B453E000173F9F /* PostTypeSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTypeSelectionView.swift; sourceTree = "<group>"; };
 		3EDDC6E029B4841B00173F9F /* ANSIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIColor.swift; sourceTree = "<group>"; };
@@ -341,6 +343,7 @@
 			children = (
 				94EB641925AD2FF800BF69AB /* KeyChainItem.swift */,
 				3EC2CB2C29BB8DAC00E70A45 /* Direction.swift */,
+				3ED0485B2A7461F9004E78BD /* FavoriteBoardManager.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1011,6 +1014,7 @@
 				3EC2CB2629BB57B000E70A45 /* UserNumberView.swift in Sources */,
 				3EC2CB2B29BB643F00E70A45 /* BoardSearchCell.swift in Sources */,
 				3EC2CB4E29C888B800E70A45 /* NotificationName.swift in Sources */,
+				3ED0485C2A7461F9004E78BD /* FavoriteBoardManager.swift in Sources */,
 				3E1694392761260500F19B8E /* PopularArticleCell.swift in Sources */,
 				94AA091F278AE1E900AD3525 /* LoginSubView.swift in Sources */,
 				3E9FE303275CFEDC002E144F /* PopularArticlesCoordinator.swift in Sources */,

--- a/Ptt.xcodeproj/project.pbxproj
+++ b/Ptt.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		3EA6F1B629B386A2005D8B09 /* ComposeArticleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA6F1B529B386A2005D8B09 /* ComposeArticleViewController.swift */; };
 		3EA6F1B829B386F1005D8B09 /* ComposeArticleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA6F1B729B386F1005D8B09 /* ComposeArticleViewModel.swift */; };
 		3EA6F1BA29B388AF005D8B09 /* ComposeArticleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA6F1B929B388AF005D8B09 /* ComposeArticleView.swift */; };
+		3EB974B62A75CEEC003A8F29 /* Codable+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB974B52A75CEEC003A8F29 /* Codable+Extension.swift */; };
 		3EC2CB2229BB53AC00E70A45 /* BoardsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2CB2129BB53AC00E70A45 /* BoardsTableViewCell.swift */; };
 		3EC2CB2429BB542C00E70A45 /* UITableViewCell+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2CB2329BB542C00E70A45 /* UITableViewCell+Extension.swift */; };
 		3EC2CB2629BB57B000E70A45 /* UserNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2CB2529BB57B000E70A45 /* UserNumberView.swift */; };
@@ -58,6 +59,7 @@
 		3EC2CB5029C88AF900E70A45 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2CB4F29C88AF900E70A45 /* String+Extension.swift */; };
 		3ECAD05D2762766A00F50A91 /* NumberExtensionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECAD05C2762766A00F50A91 /* NumberExtensionTest.swift */; };
 		3ED0485C2A7461F9004E78BD /* FavoriteBoardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED0485B2A7461F9004E78BD /* FavoriteBoardManager.swift */; };
+		3ED0485E2A75C3EB004E78BD /* FavoriteBoardManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED0485D2A75C3EB004E78BD /* FavoriteBoardManagerTest.swift */; };
 		3ED16B3E25713D64004A33E0 /* APITestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED16B3D25713D64004A33E0 /* APITestClient.swift */; };
 		3EDDC6DF29B453E000173F9F /* PostTypeSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EDDC6DE29B453E000173F9F /* PostTypeSelectionView.swift */; };
 		3EDDC6E129B4841B00173F9F /* ANSIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EDDC6E029B4841B00173F9F /* ANSIColor.swift */; };
@@ -185,6 +187,7 @@
 		3EA6F1B529B386A2005D8B09 /* ComposeArticleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeArticleViewController.swift; sourceTree = "<group>"; };
 		3EA6F1B729B386F1005D8B09 /* ComposeArticleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeArticleViewModel.swift; sourceTree = "<group>"; };
 		3EA6F1B929B388AF005D8B09 /* ComposeArticleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeArticleView.swift; sourceTree = "<group>"; };
+		3EB974B52A75CEEC003A8F29 /* Codable+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Codable+Extension.swift"; sourceTree = "<group>"; };
 		3EC2CB2129BB53AC00E70A45 /* BoardsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsTableViewCell.swift; sourceTree = "<group>"; };
 		3EC2CB2329BB542C00E70A45 /* UITableViewCell+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Extension.swift"; sourceTree = "<group>"; };
 		3EC2CB2529BB57B000E70A45 /* UserNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNumberView.swift; sourceTree = "<group>"; };
@@ -199,6 +202,7 @@
 		3EC2CB4F29C88AF900E70A45 /* String+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		3ECAD05C2762766A00F50A91 /* NumberExtensionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberExtensionTest.swift; sourceTree = "<group>"; };
 		3ED0485B2A7461F9004E78BD /* FavoriteBoardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteBoardManager.swift; sourceTree = "<group>"; };
+		3ED0485D2A75C3EB004E78BD /* FavoriteBoardManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteBoardManagerTest.swift; sourceTree = "<group>"; };
 		3ED16B3D25713D64004A33E0 /* APITestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITestClient.swift; sourceTree = "<group>"; };
 		3EDDC6DE29B453E000173F9F /* PostTypeSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTypeSelectionView.swift; sourceTree = "<group>"; };
 		3EDDC6E029B4841B00173F9F /* ANSIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIColor.swift; sourceTree = "<group>"; };
@@ -352,6 +356,7 @@
 			isa = PBXGroup;
 			children = (
 				3E15F019299E567B00651809 /* KeyChainItemTests.swift */,
+				3ED0485D2A75C3EB004E78BD /* FavoriteBoardManagerTest.swift */,
 			);
 			path = CommonTest;
 			sourceTree = "<group>";
@@ -628,6 +633,7 @@
 				3EE352E4276DDC8300C2CE67 /* TimeInterval+Extension.swift */,
 				3EC2CB2329BB542C00E70A45 /* UITableViewCell+Extension.swift */,
 				3E5A356329F555B200502407 /* UIApplication+SafeArea.swift */,
+				3EB974B52A75CEEC003A8F29 /* Codable+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -983,6 +989,7 @@
 				3E65527125595F0D0026290B /* BoardInfo.swift in Sources */,
 				9411EDAA25A0B03C0005ADCB /* LoginSceneFactoryProtocol.swift in Sources */,
 				9B564C28256A9D7800787FD7 /* Coordinatorable.swift in Sources */,
+				3EB974B62A75CEEC003A8F29 /* Codable+Extension.swift in Sources */,
 				944209D6279B029C002B2B7A /* ErrorSubView.swift in Sources */,
 				3EF5410929FD20810086205A /* ArticleCommentList.swift in Sources */,
 				9B564C2F256A9EAC00787FD7 /* Presentable.swift in Sources */,
@@ -1091,6 +1098,7 @@
 				3EE9355D29C9E7E400DCEC81 /* MockKeyChain.swift in Sources */,
 				3EE9356429CB2E3200DCEC81 /* GetBoardArticlesFakeData.swift in Sources */,
 				3E31EC492A1F8B73002D15E7 /* UserCommentFakeData.swift in Sources */,
+				3ED0485E2A75C3EB004E78BD /* FavoriteBoardManagerTest.swift in Sources */,
 				3EE352E7276DDF1000C2CE67 /* TimeIntervalExtensionTest.swift in Sources */,
 				3E15F01A299E567B00651809 /* KeyChainItemTests.swift in Sources */,
 				3EE9356229CB2C1000DCEC81 /* GetArticleFakeData.swift in Sources */,

--- a/Ptt/API/Models/BoardInfo.swift
+++ b/Ptt/API/Models/BoardInfo.swift
@@ -15,7 +15,7 @@ extension APIModel {
         var next_idx: String?
     }
 
-    struct BoardInfo: Codable {
+    struct BoardInfo: Codable, Equatable {
         /// system-defined board-id
         let bid: String
         /// user-defined board-name (英文板名)

--- a/Ptt/Common/Utilities/FavoriteBoardManager.swift
+++ b/Ptt/Common/Utilities/FavoriteBoardManager.swift
@@ -1,0 +1,116 @@
+//
+//  FavoriteBoardManager.swift
+//  Ptt
+//
+//  Created by AnsonChen on 2023/7/28.
+//  Copyright © 2023 Ptt. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+protocol FavoriteBoardManagerProtocol {
+    var boards: CurrentValueSubject<[APIModel.BoardInfo]?, Never> { get }
+
+    func addBoardToFavorite(board: APIModel.BoardInfo) async throws
+    func deleteBoardFromFavorite(board: APIModel.BoardInfo) async throws
+    func fetchAllFavoriteBoards() async throws
+    func getFetchError() async -> Error?
+}
+
+actor FavoriteBoardDataStore {
+    var favoritedBoards: [APIModel.BoardInfo]?
+    var fetchError: Error?
+    var favoriteStartIndex = ""
+    var isFetching = false
+
+    func addBoardToFavorite(board: APIModel.BoardInfo) {
+        var boards = favoritedBoards ?? []
+        boards.append(board)
+        favoritedBoards = boards
+    }
+
+    func deleteBoardFromFavorite(board: APIModel.BoardInfo) {
+        var boards = favoritedBoards ?? []
+        boards.removeAll(where: { $0.brdname == board.brdname })
+        favoritedBoards = boards
+    }
+
+    func setFavoriteBoards(boards: [APIModel.BoardInfo]) {
+        favoritedBoards = boards
+    }
+
+    func update(favoriteStartIndex: String) {
+        self.favoriteStartIndex = favoriteStartIndex
+    }
+
+    func update(fetchError: Error?) {
+        self.fetchError = fetchError
+    }
+
+    func update(isFetching: Bool) {
+        self.isFetching = isFetching
+    }
+}
+
+final class FavoriteBoardManager: FavoriteBoardManagerProtocol {
+    static let shared: FavoriteBoardManager = .init()
+    let apiClient: APIClientProtocol
+    let dataStore: FavoriteBoardDataStore
+    let boards = CurrentValueSubject<[APIModel.BoardInfo]?, Never>(nil)
+
+    init(apiClient: APIClientProtocol = APIClient.shared) {
+        self.apiClient = apiClient
+        self.dataStore = FavoriteBoardDataStore()
+    }
+
+    func addBoardToFavorite(board: APIModel.BoardInfo) async throws {
+        let levelIndex = board.level_idx ?? ""
+        let response = try await apiClient.addBoardToFavorite(levelIndex: levelIndex, bid: board.bid)
+        await dataStore.addBoardToFavorite(board: response)
+        await boards.send(dataStore.favoritedBoards)
+    }
+
+    func deleteBoardFromFavorite(board: APIModel.BoardInfo) async throws {
+        guard await dataStore.favoritedBoards != nil else { return }
+        _ = try await apiClient.deleteBoardFromFavorite(
+            levelIndex: board.level_idx ?? "",
+            index: board.idx
+        )
+        await dataStore.deleteBoardFromFavorite(board: board)
+        await boards.send(dataStore.favoritedBoards)
+    }
+
+    func fetchAllFavoriteBoards() async {
+        do {
+            if await dataStore.isFetching { return }
+            await dataStore.update(isFetching: true)
+            await dataStore.update(favoriteStartIndex: "")
+            var favoriteBoards = try await fetchFavoriteBoardsRecursive()
+            while await !dataStore.favoriteStartIndex.isEmpty {
+                let responseList = try await fetchFavoriteBoardsRecursive()
+                favoriteBoards += responseList
+            }
+            await dataStore.setFavoriteBoards(boards: favoriteBoards)
+            await boards.send(dataStore.favoritedBoards)
+            await dataStore.update(fetchError: nil)
+            await dataStore.update(isFetching: false)
+        } catch {
+            await dataStore.update(isFetching: false)
+            await dataStore.update(fetchError: error)
+            // To trigger sink after getting api error
+            await boards.send(dataStore.favoritedBoards)
+        }
+    }
+
+    private func fetchFavoriteBoardsRecursive() async throws -> [APIModel.BoardInfo] {
+        let index = await dataStore.favoriteStartIndex
+        let response = try await apiClient.favoritesBoards(startIndex: index, limit: 200)
+        await dataStore.update(favoriteStartIndex: response.next_idx ?? "")
+        return response.list
+    }
+
+    func getFetchError() async -> Error? {
+        await dataStore.fetchError
+    }
+}

--- a/Ptt/Extensions/Codable+Extension.swift
+++ b/Ptt/Extensions/Codable+Extension.swift
@@ -1,0 +1,19 @@
+//
+//  Codable+Extension.swift
+//  Ptt
+//
+//  Created by AnsonChen on 2023/7/30.
+//  Copyright © 2023 Ptt. All rights reserved.
+//
+
+import Foundation
+
+extension Encodable {
+    func asDictionary() throws -> [String: Any] {
+        let data = try JSONEncoder().encode(self)
+        guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else {
+            throw NSError()
+        }
+        return dictionary
+    }
+}

--- a/Ptt/Flows/BoardListFlow/BoardListTVC.swift
+++ b/Ptt/Flows/BoardListFlow/BoardListTVC.swift
@@ -29,7 +29,6 @@ final class BoardListTVC: UITableViewController, BoardListView {
         self.boardSearchVC = BoardSearchViewController(apiClient: viewModel.apiClient)
         self.searchController = UISearchController(searchResultsController: boardSearchVC)
         super.init(style: .plain)
-        boardSearchVC.delegate = viewModel
     }
 
     required init?(coder: NSCoder) {
@@ -39,7 +38,7 @@ final class BoardListTVC: UITableViewController, BoardListView {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpView()
-        viewModel.fetchListData()
+        viewModel.fetchPopularBoards()
     }
 
     // MARK: - Table view data source
@@ -156,12 +155,6 @@ extension BoardListTVC: BoardListUIProtocol {
         DispatchQueue.main.async {
             self.tableView.refreshControl?.endRefreshing()
             self.tableView.reloadData()
-        }
-    }
-
-    func favoriteBoardsDidUpdate() {
-        DispatchQueue.main.async {
-            self.boardSearchVC.update(favoriteBoards: self.viewModel.favoriteBoards)
         }
     }
 

--- a/Ptt/Flows/BoardListFlow/BoardListTVC.swift
+++ b/Ptt/Flows/BoardListFlow/BoardListTVC.swift
@@ -158,6 +158,12 @@ extension BoardListTVC: BoardListUIProtocol {
         }
     }
 
+    func stopRefreshing() {
+        DispatchQueue.main.async {
+            self.tableView.refreshControl?.endRefreshing()
+        }
+    }
+
     func inValidUser() {
         DispatchQueue.main.async {
             self.debug_logout()

--- a/Ptt/Flows/BoardListFlow/BoardListViewModel.swift
+++ b/Ptt/Flows/BoardListFlow/BoardListViewModel.swift
@@ -6,12 +6,12 @@
 //  Copyright © 2023 Ptt. All rights reserved.
 //
 
+import Combine
 import Foundation
 
 protocol BoardListUIProtocol: AnyObject {
     func show(error: Error)
     func listDidUpdate()
-    func favoriteBoardsDidUpdate()
     func inValidUser()
 }
 
@@ -24,35 +24,48 @@ extension BoardListViewModel {
 final class BoardListViewModel {
     let listType: ListType
     let apiClient: APIClientProtocol
+    let favoriteBoardManager: FavoriteBoardManagerProtocol
+    private var cancellable: AnyCancellable?
     private var startIndex = ""
-    private(set) var list: [APIModel.BoardInfo] = []
-    private(set) var favoriteBoards: [APIModel.BoardInfo] = []
-    private var favoriteStartIndex = ""
+    private(set) var list: [APIModel.BoardInfo] = [] {
+        didSet {
+            guard oldValue != list else { return }
+            uiDelegate?.listDidUpdate()
+        }
+    }
     weak var uiDelegate: BoardListUIProtocol?
 
-    init(listType: ListType, apiClient: APIClientProtocol = APIClient.shared) {
+    init(
+        listType: ListType,
+        apiClient: APIClientProtocol = APIClient.shared,
+        favoriteBoardManager: FavoriteBoardManagerProtocol = FavoriteBoardManager.shared
+    ) {
         self.listType = listType
         self.apiClient = apiClient
+        self.favoriteBoardManager = favoriteBoardManager
+        observeFavoriteBoard()
     }
 
-    func fetchListData() {
+    func fetchPopularBoards() {
         if case .popular = listType {
             Task { await fetchPopularBoards() }
-        }
-        Task {
-            await fetchAllFavoriteBoards()
-            if case .favorite = listType {
-                list = favoriteBoards
-                startIndex = favoriteStartIndex
-                uiDelegate?.listDidUpdate()
-            }
-            uiDelegate?.favoriteBoardsDidUpdate()
         }
     }
 
     func pullDownToRefresh() {
-        startIndex = ""
-        fetchListData()
+        switch listType {
+        case .favorite:
+            Task {
+                do {
+                    try await favoriteBoardManager.fetchAllFavoriteBoards()
+                } catch {
+                    uiDelegate?.show(error: error)
+                }
+            }
+        case.popular:
+            startIndex = ""
+            fetchPopularBoards()
+        }
     }
 
     func fetchMoreData() {
@@ -69,15 +82,7 @@ final class BoardListViewModel {
         Task {
             let board = list[index]
             do {
-                let isSuccess = try await apiClient.deleteBoardFromFavorite(
-                    levelIndex: board.level_idx ?? "",
-                    index: board.idx
-                )
-                // Failure will throw catch
-                list.remove(at: index)
-                favoriteBoards = list
-                uiDelegate?.favoriteBoardsDidUpdate()
-                uiDelegate?.listDidUpdate()
+                try await favoriteBoardManager.deleteBoardFromFavorite(board: board)
             } catch {
                 uiDelegate?.show(error: error)
             }
@@ -91,53 +96,41 @@ final class BoardListViewModel {
 }
 
 extension BoardListViewModel {
-    func fetchAllFavoriteBoards() async {
-        favoriteBoards = []
-        await fetchFavoriteBoardsRecursive()
-    }
-
-    private func fetchFavoriteBoardsRecursive() async {
-        do {
-            let response = try await apiClient.favoritesBoards(startIndex: favoriteStartIndex, limit: 200)
-            favoriteBoards += response.list
-            favoriteStartIndex = response.next_idx ?? ""
-            if !favoriteStartIndex.isEmpty {
-                await fetchFavoriteBoardsRecursive()
-            }
-        } catch {
-            if let apiError = error as? APIError,
-               case let .requestFailed(statusCode, _) = apiError,
-               statusCode == 403,
-               listType == .favorite {
-                uiDelegate?.inValidUser()
-            }
-        }
-    }
-
     private func fetchPopularBoards() async {
         do {
             let response = try await apiClient.popularBoards()
-            if startIndex == "" {
+            if startIndex.isEmpty {
                 list = response.list
             } else {
                 list += response.list
             }
             startIndex = response.next_idx ?? ""
-            uiDelegate?.listDidUpdate()
         } catch {
             uiDelegate?.show(error: error)
         }
     }
-}
 
-extension BoardListViewModel: BoardSearchDelegate {
-    func boardDidAddToFavorite(info: APIModel.BoardInfo) {
-        list.append(info)
-        uiDelegate?.listDidUpdate()
+    private func handlePossibleTokenExpire(error: Error?) {
+        if let apiError = error as? APIError,
+           case let .requestFailed(statusCode, _) = apiError,
+           statusCode == 403,
+           listType == .favorite {
+            uiDelegate?.inValidUser()
+        }
     }
 
-    func boardDidDeleteFromFavorite(info: APIModel.BoardInfo) {
-        list.removeAll(where: { $0.bid == info.bid })
-        uiDelegate?.listDidUpdate()
+    private func observeFavoriteBoard() {
+        self.cancellable = favoriteBoardManager.boards.sink { [weak self] boards in
+            guard let boards = boards else {
+                Task { [weak self] in
+                    let error = await favoriteBoardManager.getFetchError()
+                    self?.handlePossibleTokenExpire(error: error)
+                }
+                return
+            }
+            if case .favorite = self?.listType {
+                self?.list = boards
+            }
+        }
     }
 }

--- a/Ptt/Flows/MainTabBarFlow/TabBarCoordinator.swift
+++ b/Ptt/Flows/MainTabBarFlow/TabBarCoordinator.swift
@@ -33,6 +33,9 @@ class TabBarCoordinator: BaseCoordinator, TabBarCoordinatorProtocol {
 #else
         pages = [.popular, .favorite, .profile, .settings]
 #endif
+        Task {
+            try? await FavoriteBoardManager.shared.fetchAllFavoriteBoards()
+        }
         // Initialization of ViewControllers or these pages
         let controllers: [UINavigationController] = pages
             .sorted(by: { $0.pageOrderNumber < $1.pageOrderNumber })

--- a/PttTests/CommonTest/FavoriteBoardManagerTest.swift
+++ b/PttTests/CommonTest/FavoriteBoardManagerTest.swift
@@ -1,0 +1,239 @@
+//
+//  FavoriteBoardManagerTest.swift
+//  PttTests
+//
+//  Created by AnsonChen on 2023/7/30.
+//  Copyright © 2023 Ptt. All rights reserved.
+//
+
+import Combine
+import XCTest
+@testable import Ptt
+
+final class FavoriteBoardManagerTest: XCTestCase {
+    private var apiClient: APIClientProtocol!
+    private var keyChainItem: PTTKeyChain!
+    private var urlSession: MockURLSession!
+    private var sut: FavoriteBoardManager!
+    private var userID = "sampleID"
+    private var cancellables: Set<AnyCancellable>!
+
+    override func setUpWithError() throws {
+        cancellables = []
+        urlSession = MockURLSession()
+        keyChainItem = MockKeyChain()
+        keyChainItem.save(
+            object: APIModel.LoginToken(user_id: userID, access_token: "fakeToken", token_type: "bear"),
+            for: .loginToken
+        )
+
+        apiClient = APIClient(session: urlSession, keyChainItem: keyChainItem)
+        sut = FavoriteBoardManager(apiClient: apiClient)
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        cancellables = []
+        apiClient = nil
+        keyChainItem = nil
+        urlSession = nil
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testAddBoardToFavorite_receivedDataShouldFollowAddedSequence() async {
+        let boards = [mockBoardInfo(), mockBoardInfo()]
+        let ex = expectation(description: "receiveValue is called")
+        ex.expectedFulfillmentCount = 3
+        sut.boards
+            .sink { _ in
+
+            } receiveValue: { newBoards in
+                if let newBoards = newBoards {
+                    if newBoards.count == 1 {
+                        XCTAssertEqual(newBoards.map { $0.brdname }, [boards[0].brdname])
+                    } else if newBoards.count == 2 {
+                        XCTAssertEqual(newBoards.map { $0.brdname }, boards.map { $0.brdname })
+                    }
+                }
+                ex.fulfill()
+            }
+            .store(in: &cancellables)
+
+        Task {
+            stubAddFavoriteBoards(isError: false, board: boards[0])
+            try await sut.addBoardToFavorite(board: boards[0])
+        }
+
+        Task {
+            stubAddFavoriteBoards(isError: false, board: boards[1])
+            try await sut.addBoardToFavorite(board: boards[1])
+        }
+        await fulfillment(of: [ex])
+    }
+
+    func testAddBoardToFavorite_whenErrorHappensShouldThrow() async throws {
+        stubAddFavoriteBoards(isError: true, board: nil)
+        do {
+            try await sut.addBoardToFavorite(board: mockBoardInfo())
+        } catch {
+            let apiError = try XCTUnwrap(error as? APIError)
+            guard case let .requestFailed(int, _) = apiError,
+                  int == 500 else {
+                XCTFail("Unexpected error")
+                return
+            }
+        }
+    }
+
+    func testDeleteBoardFromFavorite_whenFavoritedBoardsIsEmpty_shouldIgnore() async throws {
+        let ex = expectation(description: "receiveValue is called")
+        sut.boards
+            .sink { _ in
+
+            } receiveValue: { newBoards in
+                XCTAssertNil(newBoards)
+                ex.fulfill()
+            }
+            .store(in: &cancellables)
+
+        try await sut.deleteBoardFromFavorite(board: mockBoardInfo())
+        await fulfillment(of: [ex])
+    }
+
+    func testDeleteBoardFromFavorite_successDelete() async throws {
+        let mockBoard = mockBoardInfo()
+        var expected: [[APIModel.BoardInfo]?] = [nil, [mockBoard], []]
+        let ex = expectation(description: "receiveValue is called")
+        ex.expectedFulfillmentCount = 3
+        sut.boards
+            .sink { _ in
+
+            } receiveValue: { newBoards in
+                let expectedResult = expected.removeFirst()
+                XCTAssertEqual(expectedResult, newBoards)
+                ex.fulfill()
+            }
+            .store(in: &cancellables)
+
+        stubAddFavoriteBoards(isError: false, board: mockBoard)
+        try await sut.addBoardToFavorite(board: mockBoard)
+
+        stubDeleteFavoriteBoards(isError: false)
+        try await sut.deleteBoardFromFavorite(board: mockBoard)
+
+        await fulfillment(of: [ex])
+    }
+
+    func testDeleteBoardFromFavorite_whenDeleteFailed() async throws {
+        let mockBoard = mockBoardInfo()
+        stubAddFavoriteBoards(isError: false, board: mockBoard)
+        try await sut.addBoardToFavorite(board: mockBoard)
+
+        stubDeleteFavoriteBoards(isError: true)
+        do {
+            try await sut.deleteBoardFromFavorite(board: mockBoard)
+        } catch {
+            let apiError = try XCTUnwrap(error as? APIError)
+            guard case let .requestFailed(int, _) = apiError,
+                  int == 500 else {
+                XCTFail("Unexpected error")
+                return
+            }
+        }
+    }
+
+    func testFetchAllFavoriteBoards_needsToCallAPITwice() async {
+        let ex = expectation(description: "receiveValue is called")
+        ex.expectedFulfillmentCount = 2
+        sut.boards
+            .sink { _ in
+
+            } receiveValue: { newBoards in
+                if let newBoards = newBoards {
+                    XCTAssertEqual(4, newBoards.count)
+                }
+                ex.fulfill()
+            }
+            .store(in: &cancellables)
+
+        stubFetchFavoriteBoards(isError: false, iterate: 2)
+        await sut.fetchAllFavoriteBoards()
+        await fulfillment(of: [ex])
+    }
+
+    func testFetchAllFavoriteBoards_whenErrorHappens() async throws {
+        let ex = expectation(description: "receiveValue is called")
+        sut.boards
+            .sink { completion in
+                switch completion {
+                case .failure(let error):
+                    guard let apiError = error as? APIError,
+                          case .requestFailed(let code, _) = apiError,
+                          code == 403 else {
+                        XCTFail("Unexpected error")
+                        return
+                    }
+                    ex.fulfill()
+                case .finished:
+                    XCTFail("Shouldn't finish")
+                }
+            } receiveValue: { _ in
+
+            }
+            .store(in: &cancellables)
+
+        stubFetchFavoriteBoards(isError: true, iterate: 0)
+        await sut.fetchAllFavoriteBoards()
+        await fulfillment(of: [ex])
+    }
+}
+
+extension FavoriteBoardManagerTest {
+    private func stubAddFavoriteBoards(isError: Bool, board: APIModel.BoardInfo?) {
+        urlSession.stub { path, _, _, _, completion in
+            XCTAssertEqual(path, "/api/user/\(self.userID)/favorites/addboard")
+            if isError {
+                completion(.success((500, ["Msg": "error message"])))
+            } else if let board = board,
+                      let dict = try? board.asDictionary() {
+                completion(.success((200, dict)))
+            } else {
+                XCTFail("config error")
+            }
+        }
+    }
+
+    private func stubDeleteFavoriteBoards(isError: Bool) {
+        urlSession.stub { path, _, _, _, completion in
+            XCTAssertEqual(path, "/api/user/\(self.userID)/favorites/delete")
+            if isError {
+                completion(.success((500, ["Msg": "error message"])))
+            } else {
+                completion(.success((200, ["success": true])))
+            }
+        }
+    }
+
+    private func stubFetchFavoriteBoards(isError: Bool, iterate: Int) {
+        urlSession.stub { path, _, queryItem, _, completion in
+            XCTAssertEqual(path, "/api/user/\(self.userID)/favorites")
+            if isError {
+                completion(.success((403, ["Msg": "Invalid user"])))
+            } else {
+                guard let item = queryItem.first(where: { $0.name == "start_idx" }),
+                      let value = item.value else {
+                    XCTFail("Should have start_idx")
+                    return
+                }
+                let nextIdx = value.isEmpty ? "1" : ""
+                let data = BoardListFakeData.mockSuccessData(nextIdx: nextIdx, numOfBoards: 2)
+                completion(.success((200, data)))
+            }
+        }
+    }
+
+    private func mockBoardInfo() -> APIModel.BoardInfo {
+        APIModel.BoardInfo(brdname: String.random(length: 8), title: String.random(length: 2))
+    }
+}

--- a/PttTests/FakeData/BoardListFakeData.swift
+++ b/PttTests/FakeData/BoardListFakeData.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2023 Ptt. All rights reserved.
 //
 
+@testable import Ptt
+
 enum BoardListFakeData {
     static var successData: [String: Any] = [
         "list": [
@@ -142,4 +144,16 @@ enum BoardListFakeData {
         ],
         "next_idx": ""
     ]
+
+    static func mockSuccessData(nextIdx: String, numOfBoards: Int) -> [String: Any] {
+        let boards = [Int](1...numOfBoards).map { _ in
+            return (try? APIModel.BoardInfo(brdname: String.random(length: 7), title: String.random(length: 3))
+                .asDictionary()) ?? [:]
+        }
+
+        return [
+            "list": boards,
+            "next_idx": nextIdx
+        ]
+    }
 }


### PR DESCRIPTION
Introduce `FavoriteBoardManager`, leverage combine    
Board list and search view can observe `FavoriteBoardManager` to receive change of favorite boards.  
Doesn't need to call API twice 