### PR TITLE
Clear keyChain after fresh install

### DIFF
--- a/Ptt.xcodeproj/project.pbxproj
+++ b/Ptt.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		3EA6F1B629B386A2005D8B09 /* ComposeArticleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA6F1B529B386A2005D8B09 /* ComposeArticleViewController.swift */; };
 		3EA6F1B829B386F1005D8B09 /* ComposeArticleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA6F1B729B386F1005D8B09 /* ComposeArticleViewModel.swift */; };
 		3EA6F1BA29B388AF005D8B09 /* ComposeArticleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA6F1B929B388AF005D8B09 /* ComposeArticleView.swift */; };
+		3EB974B82A7685B8003A8F29 /* UserDefaultItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB974B72A7685B8003A8F29 /* UserDefaultItem.swift */; };
 		3EC2CB2229BB53AC00E70A45 /* BoardsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2CB2129BB53AC00E70A45 /* BoardsTableViewCell.swift */; };
 		3EC2CB2429BB542C00E70A45 /* UITableViewCell+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2CB2329BB542C00E70A45 /* UITableViewCell+Extension.swift */; };
 		3EC2CB2629BB57B000E70A45 /* UserNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2CB2529BB57B000E70A45 /* UserNumberView.swift */; };
@@ -184,6 +185,7 @@
 		3EA6F1B529B386A2005D8B09 /* ComposeArticleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeArticleViewController.swift; sourceTree = "<group>"; };
 		3EA6F1B729B386F1005D8B09 /* ComposeArticleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeArticleViewModel.swift; sourceTree = "<group>"; };
 		3EA6F1B929B388AF005D8B09 /* ComposeArticleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeArticleView.swift; sourceTree = "<group>"; };
+		3EB974B72A7685B8003A8F29 /* UserDefaultItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultItem.swift; sourceTree = "<group>"; };
 		3EC2CB2129BB53AC00E70A45 /* BoardsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardsTableViewCell.swift; sourceTree = "<group>"; };
 		3EC2CB2329BB542C00E70A45 /* UITableViewCell+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Extension.swift"; sourceTree = "<group>"; };
 		3EC2CB2529BB57B000E70A45 /* UserNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNumberView.swift; sourceTree = "<group>"; };
@@ -341,6 +343,7 @@
 			children = (
 				94EB641925AD2FF800BF69AB /* KeyChainItem.swift */,
 				3EC2CB2C29BB8DAC00E70A45 /* Direction.swift */,
+				3EB974B72A7685B8003A8F29 /* UserDefaultItem.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -974,6 +977,7 @@
 				EA41D65D243EF51A0052F4A1 /* FBPageViewController.swift in Sources */,
 				CD6C1C1926AD783100EBFEA9 /* CreateArticle.swift in Sources */,
 				9B564C65256AA83100787FD7 /* TabBarView.swift in Sources */,
+				3EB974B82A7685B8003A8F29 /* UserDefaultItem.swift in Sources */,
 				3E655288255960910026290B /* FullArticle.swift in Sources */,
 				3E6552822559604C0026290B /* APIClientProtocol.swift in Sources */,
 				3E8D8C83258A511600346690 /* LoginToken.swift in Sources */,

--- a/Ptt/AppDelegate.swift
+++ b/Ptt/AppDelegate.swift
@@ -24,6 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        clearKeychainAfterFreshInstall()
         return true
     }
 
@@ -57,5 +58,13 @@ private extension AppDelegate {
             router: Router(rootController: self.rootController),
             coordinatorFactory: CoordinatorFactory()
         )
+    }
+
+    func clearKeychainAfterFreshInstall() {
+        let freshInstall: Bool = !(UserDefaultItem.getValue(for: .alreadyInstalled) ?? false)
+        if freshInstall {
+            KeyChainItem.shared.clear()
+            UserDefaultItem.set(value: true, for: .alreadyInstalled)
+        }
     }
 }

--- a/Ptt/Common/Utilities/KeyChainItem.swift
+++ b/Ptt/Common/Utilities/KeyChainItem.swift
@@ -106,4 +106,18 @@ final class KeyChainItem: PTTKeyChain {
         let status = SecItemDelete(query as CFDictionary)
         return status == errSecSuccess
     }
+
+    func clear() {
+        let secItemClasses = [
+            kSecClassGenericPassword,
+            kSecClassInternetPassword,
+            kSecClassCertificate,
+            kSecClassKey,
+            kSecClassIdentity
+        ]
+        for secItemClass in secItemClasses {
+            let dictionary = [kSecClass as String:secItemClass]
+            SecItemDelete(dictionary as CFDictionary)
+        }
+    }
 }

--- a/Ptt/Common/Utilities/UserDefaultItem.swift
+++ b/Ptt/Common/Utilities/UserDefaultItem.swift
@@ -1,0 +1,23 @@
+//
+//  UserDefaultItem.swift
+//  Ptt
+//
+//  Created by AnsonChen on 2023/7/30.
+//  Copyright © 2023 Ptt. All rights reserved.
+//
+
+import Foundation
+
+struct UserDefaultItem {
+    enum Key: String {
+        case alreadyInstalled
+    }
+
+    static func set(value: Bool, for key: Key) {
+        UserDefaults.standard.set(value, forKey: key.rawValue)
+    }
+
+    static func getValue<T>(for key: Key) -> T? {
+        UserDefaults.standard.value(forKey: key.rawValue) as? T
+    }
+}


### PR DESCRIPTION
access token is stored in keychain.  
Keychain data will be persisted after deleting app.   
That means app is logged in after re-install.  
definitely a bug     

Solution, save a flag in `UserDefault`.   
If this is fresh install, clear keychain data.  

The consequence is app will be logged out first time.  
Because the flag doesn't exist, it will be treated as fresh install 