### PR TITLE
Introduce tokenuser to validate token

### DIFF
--- a/Ptt.xcodeproj/project.pbxproj
+++ b/Ptt.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		3E31EC452A1F8586002D15E7 /* ProfileFakeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E31EC442A1F8586002D15E7 /* ProfileFakeData.swift */; };
 		3E31EC472A1F88D1002D15E7 /* UserArticlesFakeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E31EC462A1F88D1002D15E7 /* UserArticlesFakeData.swift */; };
 		3E31EC492A1F8B73002D15E7 /* UserCommentFakeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E31EC482A1F8B73002D15E7 /* UserCommentFakeData.swift */; };
+		3E4CFE0F2AEA9737001FB715 /* Data+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4CFE0E2AEA9737001FB715 /* Data+Extension.swift */; };
 		3E5A356429F555B200502407 /* UIApplication+SafeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5A356329F555B200502407 /* UIApplication+SafeArea.swift */; };
 		3E5A356629F5594F00502407 /* UserInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5A356529F5594F00502407 /* UserInfoViewModel.swift */; };
 		3E5A356929F56AC000502407 /* Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5A356829F56AC000502407 /* Profile.swift */; };
@@ -164,6 +165,7 @@
 		3E31EC442A1F8586002D15E7 /* ProfileFakeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileFakeData.swift; sourceTree = "<group>"; };
 		3E31EC462A1F88D1002D15E7 /* UserArticlesFakeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserArticlesFakeData.swift; sourceTree = "<group>"; };
 		3E31EC482A1F8B73002D15E7 /* UserCommentFakeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCommentFakeData.swift; sourceTree = "<group>"; };
+		3E4CFE0E2AEA9737001FB715 /* Data+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extension.swift"; sourceTree = "<group>"; };
 		3E5A356329F555B200502407 /* UIApplication+SafeArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+SafeArea.swift"; sourceTree = "<group>"; };
 		3E5A356529F5594F00502407 /* UserInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoViewModel.swift; sourceTree = "<group>"; };
 		3E5A356829F56AC000502407 /* Profile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
@@ -639,6 +641,7 @@
 				3EC2CB2329BB542C00E70A45 /* UITableViewCell+Extension.swift */,
 				3E5A356329F555B200502407 /* UIApplication+SafeArea.swift */,
 				3EB974B52A75CEEC003A8F29 /* Codable+Extension.swift */,
+				3E4CFE0E2AEA9737001FB715 /* Data+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1028,6 +1031,7 @@
 				3EC2CB2629BB57B000E70A45 /* UserNumberView.swift in Sources */,
 				3EC2CB2B29BB643F00E70A45 /* BoardSearchCell.swift in Sources */,
 				3EC2CB4E29C888B800E70A45 /* NotificationName.swift in Sources */,
+				3E4CFE0F2AEA9737001FB715 /* Data+Extension.swift in Sources */,
 				3ED0485C2A7461F9004E78BD /* FavoriteBoardManager.swift in Sources */,
 				3E1694392761260500F19B8E /* PopularArticleCell.swift in Sources */,
 				94AA091F278AE1E900AD3525 /* LoginSubView.swift in Sources */,

--- a/Ptt/API/Models/LoginToken.swift
+++ b/Ptt/API/Models/LoginToken.swift
@@ -27,7 +27,7 @@ extension APIModel {
             let now = Date()
             if access_expire > now {
                 return .normal
-            } else if now >= access_expire && now < refresh_expire {
+            } else if now >= access_expire && now < Date(timeInterval: -600, since: refresh_expire) {
                 return .refreshToken
             } else {
                 return .reLogIn

--- a/Ptt/Extensions/Codable+Extension.swift
+++ b/Ptt/Extensions/Codable+Extension.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable:this file_name
 //
 //  Codable+Extension.swift
 //  Ptt
@@ -11,9 +12,7 @@ import Foundation
 extension Encodable {
     func asDictionary() throws -> [String: Any] {
         let data = try JSONEncoder().encode(self)
-        guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else {
-            throw NSError()
-        }
+        guard let dictionary = try data.toDictionary() else { throw NSError() }
         return dictionary
     }
 }

--- a/Ptt/Extensions/Data+Extension.swift
+++ b/Ptt/Extensions/Data+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  Data+Extension.swift
+//  Ptt
+//
+//  Created by Anson on 2023/10/26.
+//  Copyright © 2023 Ptt. All rights reserved.
+//
+
+import Foundation
+
+extension Data {
+    func toDictionary() throws -> [String: Any]? {
+        return try JSONSerialization.jsonObject(with: self, options: []) as? [String: Any]
+    }
+}

--- a/PttTests/APITest/APIClientTest.swift
+++ b/PttTests/APITest/APIClientTest.swift
@@ -294,7 +294,7 @@ final class APIClientTest: XCTestCase {
     func testPopularBoards_succeed() async throws {
         urlSession.stub { path, headers, queryItem, _, completion in
             XCTAssertEqual(path, "/api/boards/popular")
-            XCTAssertEqual(headers.count, 0)
+            XCTAssertEqual(headers["Authorization"], "bearer \(self.token ?? "")")
             XCTAssertEqual(queryItem.count, 0)
             completion(.success((200, BoardListFakeData.successData)))
         }


### PR DESCRIPTION
1. Check if `token user` in response is `guest`.  
Since there are too many apis, I decide to check it by json dictionary    

2. now < Date(timeInterval: -600, since: refresh_expire).   
Refresh token earlier, to prevent refresh token expired 

IMO, in theory this situation shouldn't happen    
because `func fetchTokenObject()` will refresh token if needed.   
unless user change device time 